### PR TITLE
Allow CWs in subject

### DIFF
--- a/arrays.test.ts
+++ b/arrays.test.ts
@@ -38,7 +38,7 @@ describe('arrays', () => {
   });
 
   it('has no duplicates in the subjects array', () => {
-    const subjects = SUBJECTS.map((word) => word.toLowerCase());
+    const subjects = SUBJECTS.map(getWord).map((word) => word.toLowerCase());
     expect(subjects).toContainNoDuplicates();
   });
 });

--- a/arrays.ts
+++ b/arrays.ts
@@ -1,4 +1,4 @@
-import { Verb } from './types';
+import { Subject, Verb } from './types';
 
 export const VERBS: Verb[] = [
   'posted',
@@ -45,6 +45,7 @@ export const VERBS: Verb[] = [
   'noodled',
   'washed',
   { word: 'neobred', cw: 'lewd' },
+  { word: 'bred', cw: 'lewd' },
   'trained',
   'clicked',
   'chomped',
@@ -249,7 +250,7 @@ export const VERBS: Verb[] = [
   'left-aligned',
 ];
 
-export const SUBJECTS: string[] = [
+export const SUBJECTS: Subject[] = [
   'nerd',
   'dork',
   'cutie',

--- a/arrays.ts
+++ b/arrays.ts
@@ -1,6 +1,6 @@
-import { Subject, Verb } from './types';
+import { Entry } from './types';
 
-export const VERBS: Verb[] = [
+export const VERBS: Entry[] = [
   'posted',
   'beaned',
   'licked',
@@ -253,7 +253,7 @@ export const VERBS: Verb[] = [
   'shuffled',
 ];
 
-export const SUBJECTS: Subject[] = [
+export const SUBJECTS: Entry[] = [
   'nerd',
   'dork',
   'cutie',

--- a/generate.ts
+++ b/generate.ts
@@ -13,7 +13,7 @@ export const generate = (dryRun: boolean) => {
 
   let unusedVerbs = VERBS.filter((verb) => !usedVerbs.includes(getWord(verb)));
   let unusedSubjects = SUBJECTS.filter(
-    (subject) => !usedSubjects.includes(subject)
+    (subject) => !usedSubjects.includes(getWord(subject))
   );
 
   if (!unusedVerbs.length) {
@@ -30,14 +30,15 @@ export const generate = (dryRun: boolean) => {
   const subject = randomElement(unusedSubjects);
 
   const verbWord = getWord(verb);
-  const cw = getCW(verb);
+  const subjectWord = getWord(subject);
+  const cw = getCW(verb, subject);
 
   if (!dryRun) {
     saveUsedWord(USED_VERBS_PATH, verbWord);
-    saveUsedWord(USED_SUBJECTS_PATH, subject);
+    saveUsedWord(USED_SUBJECTS_PATH, subjectWord);
   }
 
-  return { post: `Get ${verbWord}, ${subject}`, cw };
+  return { post: `Get ${verbWord}, ${subjectWord}`, cw };
 };
 
 const getUsedWords = (path: string) => {

--- a/index.ts
+++ b/index.ts
@@ -15,6 +15,9 @@ const main = async ({ dryRun = false, visibility }: MainArgs) => {
 
   if (dryRun) {
     console.log(`This is a dry run, but I would have posted "${post}".`);
+    if (typeof cw !== 'undefined') {
+      console.log(`With this CW: ${cw}`);
+    }
   } else {
     postStatus(post, { visibility, contentWarning: cw });
   }

--- a/types.ts
+++ b/types.ts
@@ -8,3 +8,4 @@ export enum Visibility {
 }
 
 export type Verb = string | { word: string; cw: string };
+export type Subject = string | { word: string; cw: string };

--- a/types.ts
+++ b/types.ts
@@ -7,5 +7,4 @@ export enum Visibility {
   Direct = 'direct',
 }
 
-export type Verb = string | { word: string; cw: string };
-export type Subject = string | { word: string; cw: string };
+export type Entry = string | { word: string; cw: string };

--- a/utils.ts
+++ b/utils.ts
@@ -1,29 +1,19 @@
-import { Subject, Verb } from './types';
+import { Entry } from './types';
 
-export const getWord = (word: Verb | Subject) => {
-  if (typeof word === 'string') {
-    return word;
+export const getWord = (entry: Entry) => {
+  if (typeof entry === 'string') {
+    return entry;
   } else {
-    return word.word;
+    return entry.word;
   }
 };
 
-export const getCW = (verb: Verb, subject: Subject): string | undefined => {
-  let cw: string | undefined = undefined;
+export const getCW = (verb: Entry, subject: Entry): string | undefined => {
+  const cws = [verb, subject]
+    .map((entry) => typeof entry !== 'string' ? entry.cw : undefined)
+    .filter(item => !!item);
 
-  if (typeof verb !== 'string') {
-    cw = verb.cw;
-  }
-
-  if (typeof subject !== 'string') {
-    if (typeof cw !== 'undefined') {
-      cw += ', ' + subject.cw;
-    } else {
-      cw = subject.cw;
-    }
-  }
-
-  return cw;
+  return cws.length ? cws.join(', ') : undefined;
 };
 
 export const randomElement = <T>(array: T[]): T => {

--- a/utils.ts
+++ b/utils.ts
@@ -10,8 +10,8 @@ export const getWord = (entry: Entry) => {
 
 export const getCW = (verb: Entry, subject: Entry): string | undefined => {
   const cws = [verb, subject]
-    .map((entry) => typeof entry !== 'string' ? entry.cw : undefined)
-    .filter(item => !!item);
+    .map((entry) => (typeof entry !== 'string' ? entry.cw : undefined))
+    .filter((item) => !!item);
 
   return cws.length ? cws.join(', ') : undefined;
 };

--- a/utils.ts
+++ b/utils.ts
@@ -1,19 +1,29 @@
-import { Verb } from './types';
+import { Subject, Verb } from './types';
 
-export const getWord = (verb: Verb) => {
-  if (typeof verb === 'string') {
-    return verb;
+export const getWord = (word: Verb | Subject) => {
+  if (typeof word === 'string') {
+    return word;
   } else {
-    return verb.word;
+    return word.word;
   }
 };
 
-export const getCW = (verb: Verb) => {
-  if (typeof verb === 'string') {
-    return undefined;
-  } else {
-    return verb.cw;
+export const getCW = (verb: Verb, subject: Subject): string | undefined => {
+  let cw: string | undefined = undefined;
+
+  if (typeof verb !== 'string') {
+    cw = verb.cw;
   }
+
+  if (typeof subject !== 'string') {
+    if (typeof cw !== 'undefined') {
+      cw += ', ' + subject.cw;
+    } else {
+      cw = subject.cw;
+    }
+  }
+
+  return cw;
 };
 
 export const randomElement = <T>(array: T[]): T => {


### PR DESCRIPTION
Added the ability to CW subjects.
I'd like a bit of feedback on the implementation of CW concatenation, I've opted to just put a `,` between verb CW and subject CW, but this sometimes results in things like `lewd, agressive, agressive` or `lewd?, agressive` for example. Is this... Good enough? Or should I think of something else? Any ideas?